### PR TITLE
refac: Add GatewayConfig for target URL to provider subproject

### DIFF
--- a/apps/gateway/src/main/kotlin/com/github/thorlauridsen/GatewayApplication.kt
+++ b/apps/gateway/src/main/kotlin/com/github/thorlauridsen/GatewayApplication.kt
@@ -1,9 +1,14 @@
 package com.github.thorlauridsen
 
+import com.github.thorlauridsen.config.GatewayConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
+@EnableConfigurationProperties(
+	GatewayConfig::class,
+)
 class GatewayApplication
 
 fun main(args: Array<String>) {

--- a/apps/gateway/src/main/kotlin/com/github/thorlauridsen/config/GatewayConfig.kt
+++ b/apps/gateway/src/main/kotlin/com/github/thorlauridsen/config/GatewayConfig.kt
@@ -1,0 +1,15 @@
+package com.github.thorlauridsen.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration properties for the gateway subproject.
+ * @param targetUrl URL of the target service.
+ */
+@ConfigurationProperties(prefix = "gateway.settings")
+class GatewayConfig(
+    /**
+     * URL of the target service.
+     */
+    val targetUrl: String,
+)

--- a/apps/gateway/src/main/kotlin/com/github/thorlauridsen/service/TravelService.kt
+++ b/apps/gateway/src/main/kotlin/com/github/thorlauridsen/service/TravelService.kt
@@ -3,6 +3,7 @@ package com.github.thorlauridsen.service
 import com.github.thorlauridsen.Flight
 import com.github.thorlauridsen.Hotel
 import com.github.thorlauridsen.RentalCar
+import com.github.thorlauridsen.config.GatewayConfig
 import com.github.thorlauridsen.dto.TravelDetailsDto
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -28,13 +29,17 @@ import java.time.OffsetDateTime
  *
  * The provider subproject exposes endpoints for hotels, flights, and rental cars.
  * The endpoints have simulated delays to demonstrate the benefits of using coroutines.
+ *
+ * @param client [WebClient] for making HTTP requests.
+ * @param gatewayConfig [GatewayConfig] configuration for the target URL.
  */
 @Service
-class TravelService {
+class TravelService(
+    private val client: WebClient,
+    private val gatewayConfig: GatewayConfig,
+) {
 
-    private val targetUrl = "http://localhost:8081"
     private val logger = LoggerFactory.getLogger(TravelService::class.java)
-    private val client = WebClient.create(targetUrl)
 
     /**
      * Fetch data from the target URL.
@@ -106,7 +111,7 @@ class TravelService {
      */
     suspend fun getAsync(): TravelDetailsDto {
         return measureExecutionTime {
-            logger.info("Fetching travel details asynchronously from $targetUrl")
+            logger.info("Fetching travel details asynchronously from ${gatewayConfig.targetUrl}")
             getDetailsAsync()
         }
     }
@@ -117,7 +122,7 @@ class TravelService {
      */
     suspend fun getSync(): TravelDetailsDto {
         return measureExecutionTime {
-            logger.info("Fetching travel details synchronously from $targetUrl")
+            logger.info("Fetching travel details synchronously from ${gatewayConfig.targetUrl}")
             getDetailsSync()
         }
     }

--- a/apps/gateway/src/main/kotlin/com/github/thorlauridsen/service/WebClientProvider.kt
+++ b/apps/gateway/src/main/kotlin/com/github/thorlauridsen/service/WebClientProvider.kt
@@ -1,0 +1,23 @@
+package com.github.thorlauridsen.service
+
+import com.github.thorlauridsen.config.GatewayConfig
+import org.springframework.context.annotation.Bean
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+
+/**
+ * Provides a [WebClient] bean.
+ * @param gatewayConfig [GatewayConfig] configuration.
+ */
+@Component
+class WebClientProvider(private val gatewayConfig: GatewayConfig) {
+
+    /**
+     * Creates a [WebClient] bean with the target URL from [GatewayConfig].
+     * @return [WebClient] bean.
+     */
+    @Bean
+    fun webClient(): WebClient {
+        return WebClient.create(gatewayConfig.targetUrl)
+    }
+}

--- a/apps/gateway/src/main/resources/application.yml
+++ b/apps/gateway/src/main/resources/application.yml
@@ -7,3 +7,6 @@ springdoc:
   swagger-ui:
     enabled: true
     path: /
+gateway:
+  settings:
+    targetUrl: http://localhost:8081


### PR DESCRIPTION
Add configuration including target URL to `provider` subproject:
- Update `application.yml` in `gateway` subproject to contain the target URL for the `provider` subproject.
- Add `GatewayConfig` which automatically reads from `application.yml`.
- Update `GatewayApplication` to enable `GatewayConfig`.
- Add `WebClientProvider` which provides a `WebClient` bean with the given target URL from `GatewayConfig`.
- Inject the `WebClient` in `TravelService`.