### PR TITLE
feat: Add Docker and docker-compose.yml

### DIFF
--- a/apps/gateway/src/main/resources/application.yml
+++ b/apps/gateway/src/main/resources/application.yml
@@ -9,4 +9,4 @@ springdoc:
     path: /
 gateway:
   settings:
-    targetUrl: http://localhost:8081
+    targetUrl: ${GATEWAY_TARGET_URL:http://localhost:8081}

--- a/apps/provider/build.gradle.kts
+++ b/apps/provider/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
 	// H2 in-memory database
 	runtimeOnly(local.h2database)
 
+	// PostgreSQL database driver
+	runtimeOnly(local.postgres)
+
 	// FasterXML Jackson module for Kotlin support
 	implementation(local.jackson.module.kotlin)
 

--- a/apps/provider/src/main/resources/application.yml
+++ b/apps/provider/src/main/resources/application.yml
@@ -2,6 +2,10 @@ server:
   port : 8081
   shutdown: graceful
 spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1}
+    username: ${SPRING_DATASOURCE_USERNAME:sa}
+    password: ${SPRING_DATASOURCE_PASSWORD:}
   liquibase:
     enabled: true
 springdoc:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+services:
+  postgres:
+    image: postgres:17
+    container_name: postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: sample-db
+    ports:
+      - "5432:5432"
+    restart: unless-stopped
+    networks:
+      - service-network
+
+  provider:
+    build:
+      context: .
+      dockerfile: docker/provider/Dockerfile
+    container_name: spring-webflux-kotlin-async-provider
+    depends_on:
+      - postgres
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/sample-db
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: postgres
+    image: spring-webflux-kotlin-async-provider:latest
+    ports:
+      - "8081:8081"
+    restart: unless-stopped
+    networks:
+      - service-network
+
+  gateway:
+    build:
+      context: .
+      dockerfile: docker/gateway/Dockerfile
+    container_name: spring-webflux-kotlin-async-gateway
+    environment:
+      GATEWAY_TARGET_URL: http://provider:8081
+    image: spring-webflux-kotlin-async-gateway:latest
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+    networks:
+      - service-network
+
+networks:
+  service-network:
+    driver: bridge

--- a/docker/gateway/Dockerfile
+++ b/docker/gateway/Dockerfile
@@ -1,0 +1,33 @@
+# Stage 1: Build the application using a Gradle image with JDK 21.
+FROM gradle:8.13.0-jdk21-corretto AS builder
+WORKDIR /home/gradle/project
+
+# Copy Gradle files from the correct locations.
+COPY gradlew gradlew.bat ./
+COPY gradle/wrapper/ gradle/wrapper/
+COPY gradle/local.versions.toml gradle/
+COPY settings.gradle.kts ./
+COPY build.gradle.kts ./
+
+# Make gradlew executable.
+RUN chmod +x gradlew
+
+# Download dependencies (this layer will be cached unless build files change).
+RUN ./gradlew --no-daemon dependencies
+
+# Copy the rest of the source code.
+COPY . .
+
+# Build the gateway subproject.
+# Exclude tests to speed up the build.
+RUN ./gradlew --no-daemon :gateway:clean :gateway:build -x test
+
+# Stage 2: Package the application into a runtime image using temurin JDK 21.
+FROM eclipse-temurin:21-jdk
+WORKDIR /app
+
+# Copy the generated jar from the builder stage.
+COPY --from=builder /home/gradle/project/apps/gateway/build/libs/gateway.jar app.jar
+
+# Run the application.
+CMD ["java", "-jar", "app.jar"]

--- a/docker/provider/Dockerfile
+++ b/docker/provider/Dockerfile
@@ -1,0 +1,33 @@
+# Stage 1: Build the application using a Gradle image with JDK 21.
+FROM gradle:8.13.0-jdk21-corretto AS builder
+WORKDIR /home/gradle/project
+
+# Copy Gradle files from the correct locations.
+COPY gradlew gradlew.bat ./
+COPY gradle/wrapper/ gradle/wrapper/
+COPY gradle/local.versions.toml gradle/
+COPY settings.gradle.kts ./
+COPY build.gradle.kts ./
+
+# Make gradlew executable.
+RUN chmod +x gradlew
+
+# Download dependencies (this layer will be cached unless build files change).
+RUN ./gradlew --no-daemon dependencies
+
+# Copy the rest of the source code.
+COPY . .
+
+# Build the provider subproject.
+# Exclude tests to speed up the build.
+RUN ./gradlew --no-daemon :provider:clean :provider:build -x test
+
+# Stage 2: Package the application into a runtime image using temurin JDK 21.
+FROM eclipse-temurin:21-jdk
+WORKDIR /app
+
+# Copy the generated jar from the builder stage.
+COPY --from=builder /home/gradle/project/apps/provider/build/libs/provider.jar app.jar
+
+# Run the application.
+CMD ["java", "-jar", "app.jar"]

--- a/gradle/local.versions.toml
+++ b/gradle/local.versions.toml
@@ -6,40 +6,43 @@ jackson = "2.18.3"
 junitPlatformLauncher = "1.11.4"
 kotlin = "2.1.20"
 liquibase = "4.31.1"
+postgres = "42.7.5"
 springboot = "3.4.4"
 springDependencyPlugin = "1.1.7"
 springdoc = "2.8.5"
 
 [libraries]
-
-# Spring Boot libraries
-springboot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "springboot" }
-springboot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux", version.ref = "springboot" }
-springboot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springboot" }
-
-# Kotlin Coroutines
-kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
-kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
-kotlin-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "coroutines" }
-
-# Springdoc provides swagger docs with support for Spring WebFlux
-springdoc-openapi-starter-webflux = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }
-
 # JetBrains Exposed provides a lightweight Kotlin SQL library
 exposed-springboot-starter = { module = "org.jetbrains.exposed:exposed-spring-boot-starter", version.ref = "exposed" }
 
 # H2 for in-memory database
 h2database = { module = "com.h2database:h2", version.ref = "h2database" }
 
-# Liquibase for managing database changelogs
-liquibase-core = { module = "org.liquibase:liquibase-core", version.ref = "liquibase" }
-
 # FasterXML Jackson module for Kotlin support
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 
 # Test libraries
-kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatformLauncher" }
+kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }
+
+# Kotlin Coroutines
+kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+kotlin-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "coroutines" }
+
+# Liquibase for managing database changelogs
+liquibase-core = { module = "org.liquibase:liquibase-core", version.ref = "liquibase" }
+
+# PostgreSQL for live database
+postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
+
+# Spring Boot libraries
+springboot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "springboot" }
+springboot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux", version.ref = "springboot" }
+springboot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springboot" }
+
+# Springdoc provides swagger docs with support for Spring WebFlux
+springdoc-openapi-starter-webflux = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }
 
 [plugins]
 springboot = { id = "org.springframework.boot", version.ref = "springboot" }


### PR DESCRIPTION
- Update `application.yml` to to use environment variable `GATEWAY_TARGET_URL`.
- Add `docker/gateway/Dockerfile` which will build a runnable docker image for the `gateway` subproject.
- Add `docker/provider/Dockerfile` which will build a runnable docker image for the `provider` subproject.
- Add PostgreSQL Gradle dependency.
- Update `application.yml` to include environment variables for the datasource. The default values will be for the H2 in-memory database but you can configure these environment variables to connect to a PostgreSQL database instead.
- Add `docker-compose.yml` which will run a PostgreSQL image and build the two Spring Boot instances from their Dockerfiles and run everything together. 

This allows you to run the entire project with a PostgreSQL database using:
```
docker compose up -d
```