### PR TITLE
refac: Use RestController and RestControllerAdvice for pure REST APIs

### DIFF
--- a/apps/gateway/src/main/kotlin/com/github/thorlauridsen/controller/TravelController.kt
+++ b/apps/gateway/src/main/kotlin/com/github/thorlauridsen/controller/TravelController.kt
@@ -3,7 +3,7 @@ package com.github.thorlauridsen.controller
 import com.github.thorlauridsen.model.TravelDetails
 import com.github.thorlauridsen.service.TravelService
 import org.springframework.http.ResponseEntity
-import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RestController
 
 /**
  * This REST controller consists of endpoints for:
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Controller
  *
  * @param travelService [TravelService] service layer.
  */
-@Controller
+@RestController
 class TravelController(private val travelService: TravelService) : ITravelController {
 
     /**

--- a/apps/provider/src/main/kotlin/com/github/thorlauridsen/controller/FlightController.kt
+++ b/apps/provider/src/main/kotlin/com/github/thorlauridsen/controller/FlightController.kt
@@ -3,7 +3,7 @@ package com.github.thorlauridsen.controller
 import com.github.thorlauridsen.model.Flight
 import com.github.thorlauridsen.service.FlightService
 import org.springframework.http.ResponseEntity
-import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RestController
 
 /**
  * This REST controller consists of endpoints for:
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Controller
  *
  * @param flightService [FlightService] service layer.
  */
-@Controller
+@RestController
 class FlightController(private val flightService: FlightService) : IFlightController {
 
     /**

--- a/apps/provider/src/main/kotlin/com/github/thorlauridsen/controller/HotelController.kt
+++ b/apps/provider/src/main/kotlin/com/github/thorlauridsen/controller/HotelController.kt
@@ -3,7 +3,7 @@ package com.github.thorlauridsen.controller
 import com.github.thorlauridsen.model.Hotel
 import com.github.thorlauridsen.service.HotelService
 import org.springframework.http.ResponseEntity
-import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RestController
 
 /**
  * This REST controller consists of endpoints for:
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Controller
  *
  * @param hotelService [HotelService] service layer.
  */
-@Controller
+@RestController
 class HotelController(private val hotelService: HotelService) : IHotelController {
 
     /**

--- a/apps/provider/src/main/kotlin/com/github/thorlauridsen/controller/RentalCarController.kt
+++ b/apps/provider/src/main/kotlin/com/github/thorlauridsen/controller/RentalCarController.kt
@@ -3,7 +3,7 @@ package com.github.thorlauridsen.controller
 import com.github.thorlauridsen.model.RentalCar
 import com.github.thorlauridsen.service.RentalCarService
 import org.springframework.http.ResponseEntity
-import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RestController
 
 /**
  * This REST controller consists of endpoints for:
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Controller
  *
  * @param rentalCarService [RentalCarService] service layer.
  */
-@Controller
+@RestController
 class RentalCarController(private val rentalCarService: RentalCarService) : IRentalCarController {
 
     /**


### PR DESCRIPTION
We should always use the annotations `RestController` and `RestControllerAdvice` for pure REST APIs. This commit updates the Spring Boot annotations.